### PR TITLE
Move exchange declaration from MessagingBackgroundService to MessageSubscriber

### DIFF
--- a/src/SuperStore.Carts/Services/MessagingBackgroundService.cs
+++ b/src/SuperStore.Carts/Services/MessagingBackgroundService.cs
@@ -5,24 +5,17 @@ namespace SuperStore.Carts.Services;
 
 internal sealed class MessagingBackgroundService : BackgroundService
 {
-    private readonly IChannelFactory _channelFactory;
     private readonly IMessageSubscriber _messageSubscriber;
     private readonly ILogger<MessagingBackgroundService> _logger;
 
-    public MessagingBackgroundService(IChannelFactory channelFactory, IMessageSubscriber messageSubscriber, 
-        ILogger<MessagingBackgroundService> logger)
+    public MessagingBackgroundService(IMessageSubscriber messageSubscriber, ILogger<MessagingBackgroundService> logger)
     {
-        _channelFactory = channelFactory;
         _messageSubscriber = messageSubscriber;
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var channel = _channelFactory.Create();
-        
-        channel.ExchangeDeclare("Funds", "topic", durable: false, autoDelete: false, null);
-        
         _messageSubscriber
             .SubscribeMessage<FundsMessage>("carts-service-eu-many-words-queue", "EU.#", "Funds",
                 (msg, args) =>

--- a/src/SuperStore.Shared/Subscribers/MessageSubscriber.cs
+++ b/src/SuperStore.Shared/Subscribers/MessageSubscriber.cs
@@ -15,6 +15,7 @@ internal sealed class MessageSubscriber : IMessageSubscriber
     public IMessageSubscriber SubscribeMessage<TMessage>(string queue, string routingKey, string exchange, 
         Func<TMessage, BasicDeliverEventArgs, Task> handle) where TMessage : class, IMessage
     {
+        _channel.ExchangeDeclare(exchange, "topic", durable: false, autoDelete: false, null);
         _channel.QueueDeclare(queue, durable: false, autoDelete: false, exclusive: false);
         _channel.QueueBind(queue, exchange, routingKey);
 


### PR DESCRIPTION
Hi Dariusz!

Thank you very much you and Peter for all your recent videos. Amazing and valuable content! 

While watching your first video about messaging  I noticed one particular place that doesn't look good and could be relatively easy improved. Moving the declaration of the exchange to MessageSubscriber will eliminate the requirement to declare it in all future usages. Please have a look at this PR